### PR TITLE
Refactor: remove header

### DIFF
--- a/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractAction.java
+++ b/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractAction.java
@@ -1,11 +1,31 @@
 package com.modyo.ms.commons.statemachine.generic;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
 public abstract class AbstractAction<T, S, E> implements Action<S, E> {
 
-  protected abstract String getEntityHeaderName();
+  final Class<T> typeParameterClass;
+
+  protected AbstractAction() {
+    Type superclass = this.getClass().getGenericSuperclass();
+    if (!(superclass instanceof ParameterizedType)) {
+      throw new IllegalStateException("Superclass is not a ParameterizedType");
+    }
+
+    Type[] actualTypeArguments = ((ParameterizedType) superclass).getActualTypeArguments();
+    if (actualTypeArguments.length == 0) {
+      throw new IllegalStateException("Actual type arguments are empty");
+    }
+    typeParameterClass = (Class<T>) actualTypeArguments[0];
+
+  }
+
+  private String getEntityHeaderName(){
+    return typeParameterClass.getName();
+  }
 
   protected T getEntity(StateContext<S, E> context) {
     return (T) context.getMessageHeader(getEntityHeaderName());

--- a/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractGuard.java
+++ b/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractGuard.java
@@ -1,11 +1,30 @@
 package com.modyo.ms.commons.statemachine.generic;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.guard.Guard;
 
 public abstract class AbstractGuard<T, S, E> implements Guard<S, E> {
+  final Class<T> typeParameterClass;
 
-  protected abstract String getEntityHeaderName();
+  protected AbstractGuard() {
+    Type superclass = this.getClass().getGenericSuperclass();
+    if (!(superclass instanceof ParameterizedType)) {
+      throw new IllegalStateException("Superclass is not a ParameterizedType");
+    }
+
+    Type[] actualTypeArguments = ((ParameterizedType) superclass).getActualTypeArguments();
+    if (actualTypeArguments.length == 0) {
+      throw new IllegalStateException("Actual type arguments are empty");
+    }
+    typeParameterClass = (Class<T>) actualTypeArguments[0];
+
+  }
+
+  private String getEntityHeaderName(){
+    return typeParameterClass.getName();
+  }
 
   protected T getEntity(StateContext<S, E> context) {
     return (T) context.getMessageHeader(getEntityHeaderName());

--- a/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractStateMachinePersistInterceptor.java
+++ b/src/main/java/com/modyo/ms/commons/statemachine/generic/AbstractStateMachinePersistInterceptor.java
@@ -16,8 +16,6 @@ public abstract class AbstractStateMachinePersistInterceptor<T, S, E> extends St
 
   final Class<T> typeParameterClass;
 
-  public abstract String getEntityHeaderName();
-
   protected abstract void saveEntity(T entity);
 
   protected abstract void updateState(T entity, S state);
@@ -37,6 +35,11 @@ public abstract class AbstractStateMachinePersistInterceptor<T, S, E> extends St
       throw new IllegalStateException("Actual type arguments are empty");
     }
     typeParameterClass = (Class<T>) actualTypeArguments[0];
+
+  }
+
+  public String getEntityHeaderName() {
+    return typeParameterClass.getName();
   }
 
   @Override

--- a/src/main/java/com/modyo/test/statemachine/adapters/persistence/SolicitudJpaEntity.java
+++ b/src/main/java/com/modyo/test/statemachine/adapters/persistence/SolicitudJpaEntity.java
@@ -7,6 +7,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "solicitud")
+@Table(name = "solicitud", indexes = {@Index(columnList = "state")})
 public class SolicitudJpaEntity {
 
   @Id

--- a/src/main/java/com/modyo/test/statemachine/application/service/StateChangePersistenceInterceptor.java
+++ b/src/main/java/com/modyo/test/statemachine/application/service/StateChangePersistenceInterceptor.java
@@ -1,7 +1,5 @@
 package com.modyo.test.statemachine.application.service;
 
-import static com.modyo.test.statemachine.config.StateMachineConfig.SM_ENTITY_HEADER;
-
 import com.modyo.ms.commons.statemachine.generic.AbstractStateMachinePersistInterceptor;
 import com.modyo.test.statemachine.application.port.out.SaveSolicitudPort;
 import com.modyo.test.statemachine.domain.model.Estado;
@@ -16,11 +14,6 @@ public class StateChangePersistenceInterceptor
 
   @Autowired
   private SaveSolicitudPort savePort;
-
-  @Override
-  public String getEntityHeaderName() {
-    return SM_ENTITY_HEADER;
-  }
 
   @Override
   protected void saveEntity(Solicitud entity) {

--- a/src/main/java/com/modyo/test/statemachine/application/service/actions/S1EntryAction.java
+++ b/src/main/java/com/modyo/test/statemachine/application/service/actions/S1EntryAction.java
@@ -3,7 +3,6 @@ package com.modyo.test.statemachine.application.service.actions;
 import com.modyo.ms.commons.core.exceptions.TechnicalErrorException;
 import com.modyo.ms.commons.statemachine.generic.AbstractAction;
 import com.modyo.test.statemachine.application.port.out.LoadSolicitudPort;
-import com.modyo.test.statemachine.config.StateMachineConfig;
 import com.modyo.test.statemachine.domain.model.Estado;
 import com.modyo.test.statemachine.domain.model.Evento;
 import com.modyo.test.statemachine.domain.model.Solicitud;
@@ -31,8 +30,4 @@ public class S1EntryAction extends AbstractAction<Solicitud, Estado, Evento> {
     }
   }
 
-  @Override
-  protected String getEntityHeaderName() {
-    return StateMachineConfig.SM_ENTITY_HEADER;
-  }
 }

--- a/src/main/java/com/modyo/test/statemachine/application/service/actions/S1ExitAction.java
+++ b/src/main/java/com/modyo/test/statemachine/application/service/actions/S1ExitAction.java
@@ -2,7 +2,6 @@ package com.modyo.test.statemachine.application.service.actions;
 
 import com.modyo.ms.commons.core.exceptions.TechnicalErrorException;
 import com.modyo.ms.commons.statemachine.generic.AbstractAction;
-import com.modyo.test.statemachine.config.StateMachineConfig;
 import com.modyo.test.statemachine.domain.model.Estado;
 import com.modyo.test.statemachine.domain.model.Evento;
 import com.modyo.test.statemachine.domain.model.Solicitud;
@@ -25,8 +24,4 @@ public class S1ExitAction extends AbstractAction<Solicitud, Estado, Evento> {
     }
   }
 
-  @Override
-  protected String getEntityHeaderName() {
-    return StateMachineConfig.SM_ENTITY_HEADER;
-  }
 }

--- a/src/main/java/com/modyo/test/statemachine/application/service/guards/S2Guard.java
+++ b/src/main/java/com/modyo/test/statemachine/application/service/guards/S2Guard.java
@@ -1,7 +1,6 @@
 package com.modyo.test.statemachine.application.service.guards;
 
 import com.modyo.ms.commons.statemachine.generic.AbstractGuard;
-import com.modyo.test.statemachine.config.StateMachineConfig;
 import com.modyo.test.statemachine.domain.model.Estado;
 import com.modyo.test.statemachine.domain.model.Evento;
 import com.modyo.test.statemachine.domain.model.Solicitud;
@@ -23,8 +22,4 @@ public class S2Guard extends AbstractGuard<Solicitud, Estado, Evento> {
     return result;
   }
 
-  @Override
-  protected String getEntityHeaderName() {
-    return StateMachineConfig.SM_ENTITY_HEADER;
-  }
 }

--- a/src/main/java/com/modyo/test/statemachine/application/service/guards/S3Guard.java
+++ b/src/main/java/com/modyo/test/statemachine/application/service/guards/S3Guard.java
@@ -1,7 +1,6 @@
 package com.modyo.test.statemachine.application.service.guards;
 
 import com.modyo.ms.commons.statemachine.generic.AbstractGuard;
-import com.modyo.test.statemachine.config.StateMachineConfig;
 import com.modyo.test.statemachine.domain.model.Estado;
 import com.modyo.test.statemachine.domain.model.Evento;
 import com.modyo.test.statemachine.domain.model.Solicitud;
@@ -12,11 +11,6 @@ import org.springframework.stereotype.Component;
 @Component("s3Guard")
 @Slf4j
 public class S3Guard extends AbstractGuard<Solicitud, Estado, Evento> {
-
-  @Override
-  protected String getEntityHeaderName() {
-    return StateMachineConfig.SM_ENTITY_HEADER;
-  }
 
   @Override
   public boolean evaluate(StateContext<Estado, Evento> context) {

--- a/src/main/java/com/modyo/test/statemachine/config/StateMachineConfig.java
+++ b/src/main/java/com/modyo/test/statemachine/config/StateMachineConfig.java
@@ -19,7 +19,6 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 @RequiredArgsConstructor
 public class StateMachineConfig extends StateMachineConfigurerAdapter<Estado, Evento> {
 
-  public static final String SM_ENTITY_HEADER = "solicitud";
   private final DefaultStateChangeLoggerListener<Estado, Evento> stateChangeLoggerListener;
   private final StateMachineComponentsCatalog<Estado, Evento> componentsCatalog;
 

--- a/src/test/java/com/modyo/test/statemachine/application/service/StateChangePersistenceInterceptorTest.java
+++ b/src/test/java/com/modyo/test/statemachine/application/service/StateChangePersistenceInterceptorTest.java
@@ -1,6 +1,5 @@
 package com.modyo.test.statemachine.application.service;
 
-import static com.modyo.test.statemachine.config.StateMachineConfig.SM_ENTITY_HEADER;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -49,7 +48,7 @@ class StateChangePersistenceInterceptorTest {
   void preStateChange_SolicitudNotFound_DoNothing() {
     Message<Evento> message = mock(Message.class);
     var headers = new HashMap<String, Object>();
-    headers.put(SM_ENTITY_HEADER, null);
+    headers.put("header", null);
     when(message.getHeaders()).thenReturn(new MessageHeaders(headers));
     assertDoesNotThrow(() -> interceptor.preStateChange(null, message, null, null, null));
   }

--- a/src/test/java/com/modyo/test/statemachine/application/service/guards/S3GuardTest.java
+++ b/src/test/java/com/modyo/test/statemachine/application/service/guards/S3GuardTest.java
@@ -1,10 +1,8 @@
 package com.modyo.test.statemachine.application.service.guards;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
-import com.modyo.test.statemachine.config.StateMachineConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +16,6 @@ class S3GuardTest {
 
   @Autowired
   private S3Guard s3Guard;
-
-  @Test
-  void testConstructor() {
-    assertEquals(StateMachineConfig.SM_ENTITY_HEADER, (new S3Guard()).getEntityHeaderName());
-  }
 
   @Test
   void testEvaluate_AllwaysReturnsFalse() {


### PR DESCRIPTION
replace SM_ENTITY_HEADER with Entity Class Name

- the entity class name is used as Header to encapsulate it within the sent messages.